### PR TITLE
GOTR: Fixed irregular bugs

### DIFF
--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsConfig.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsConfig.java
@@ -97,4 +97,14 @@ public interface AutoRiftsConfig extends Config {
     default boolean prioritizeHighTier() {
         return true;
     }
+
+    @ConfigItem(
+            keyName = "prioritizePortal",
+            name = "Prioritize Portal(BETA)",
+            description = "Prioritizes Portal, mainly affects when to drop/deposit runes - Expect some bugs",
+            position = 10
+    )
+    default boolean prioritizePortal() {
+        return true;
+    }
 }

--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsOverlay.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsOverlay.java
@@ -18,6 +18,7 @@ public class AutoRiftsOverlay extends OverlayPanel {
 
     @Override
     public Dimension render(Graphics2D graphics) {
+        panelComponent.setPreferredSize(new Dimension(200, 320));
         panelComponent.getChildren().add(TitleComponent.builder()
                 .text("Auto Rifts")
                 .color(Color.WHITE)

--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
@@ -682,6 +682,15 @@ public class AutoRiftsPlugin extends Plugin {
             return State.POWER_GUARDIAN;
         }
 
+        if(!config.prioritizePortal()){ //old way - non prioritize portal
+            if (shouldDepositRunes()) {
+                if (config.dropRunes()) {
+                    return State.DROP_RUNES;
+                }
+                return State.DEPOSIT_RUNES;
+            }
+        }
+
         if (hasTalisman()) {
             return State.DROP_TALISMAN;
         }
@@ -721,11 +730,13 @@ public class AutoRiftsPlugin extends Plugin {
             }
         }
 
-        if (shouldDepositRunes()) {
-            if (config.dropRunes()) {
-                return State.DROP_RUNES;
+        if(config.prioritizePortal()){
+            if (shouldDepositRunes()) {
+                if (config.dropRunes()) {
+                    return State.DROP_RUNES;
+                }
+                return State.DEPOSIT_RUNES;
             }
-            return State.DEPOSIT_RUNES;
         }
 
         if (hasGuardianEssence() && gameStarted) {

--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
@@ -234,14 +234,8 @@ public class AutoRiftsPlugin extends Plugin {
             gameStarted = true;
         }
 
-        if (event.getMessage().contains(Constants.GAME_OVER)) {
+        if (event.getMessage().contains(Constants.GAME_OVER) || event.getMessage().contains(Constants.GAME_WIN)) {
 
-            gameStarted = false;
-            setEssenceInPouches(0);
-            attackStarted = false;
-        }
-
-        if (event.getMessage().contains(Constants.GAME_WIN)) {
             gameStarted = false;
             setEssenceInPouches(0);
             attackStarted = false;
@@ -632,6 +626,10 @@ public class AutoRiftsPlugin extends Plugin {
                     return State.CRAFT_ESSENCE;
                 }
 
+                if(hasEnoughFrags() && hasAnyGuardianEssence() && gameStarted){
+                    return State.ENTER_RIFT;
+                }
+
                 if (isPortalSpawned() && !Inventory.full() &&gameStarted) {
                     return State.ENTER_PORTAL;
                 }
@@ -684,13 +682,6 @@ public class AutoRiftsPlugin extends Plugin {
             return State.POWER_GUARDIAN;
         }
 
-        if (shouldDepositRunes()) {
-            if (config.dropRunes()) {
-                return State.DROP_RUNES;
-            }
-            return State.DEPOSIT_RUNES;
-        }
-
         if (hasTalisman()) {
             return State.DROP_TALISMAN;
         }
@@ -728,6 +719,13 @@ public class AutoRiftsPlugin extends Plugin {
             } else {
                 return State.ENTER_PORTAL;
             }
+        }
+
+        if (shouldDepositRunes()) {
+            if (config.dropRunes()) {
+                return State.DROP_RUNES;
+            }
+            return State.DEPOSIT_RUNES;
         }
 
         if (hasGuardianEssence() && gameStarted) {
@@ -911,7 +909,10 @@ public class AutoRiftsPlugin extends Plugin {
     }
 
     private boolean isPortalSpawned() {
-        return ObjectUtil.nameContainsNoCase(Constants.PORTAL).filter(tileObject -> tileObject.getWorldLocation().getY() > Constants.OUTSIDE_BARRIER_Y).nearestToPlayer().isPresent();
+        Optional<TileObject> portal = TileObjects.search().withName(Constants.PORTAL).withAction("Enter").first();
+        if(portal.isEmpty()){ return false;}
+
+        return portal.get().getWorldLocation().getY() > Constants.OUTSIDE_BARRIER_Y;
     }
 
 

--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
@@ -909,7 +909,7 @@ public class AutoRiftsPlugin extends Plugin {
     }
 
     private boolean isPortalSpawned() {
-        Optional<TileObject> portal = TileObjects.search().withName(Constants.PORTAL).withAction("Enter").withId(43729).filter(portalObject -> portalObject.getWorldLocation().getY() > Constants.OUTSIDE_BARRIER_Y).first();
+        Optional<TileObject> portal = TileObjects.search().withName(Constants.PORTAL).withAction("Enter").withId(Constants.PORTAL_SPAWN).filter(portalObject -> portalObject.getWorldLocation().getY() > Constants.OUTSIDE_BARRIER_Y).first();
         if(portal.isEmpty()){ return false;}
 
         return true;

--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
@@ -909,10 +909,10 @@ public class AutoRiftsPlugin extends Plugin {
     }
 
     private boolean isPortalSpawned() {
-        Optional<TileObject> portal = TileObjects.search().withName(Constants.PORTAL).withAction("Enter").first();
+        Optional<TileObject> portal = TileObjects.search().withName(Constants.PORTAL).withAction("Enter").withId(43729).filter(portalObject -> portalObject.getWorldLocation().getY() > Constants.OUTSIDE_BARRIER_Y).first();
         if(portal.isEmpty()){ return false;}
 
-        return portal.get().getWorldLocation().getY() > Constants.OUTSIDE_BARRIER_Y;
+        return true;
     }
 
 

--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/data/Constants.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/data/Constants.java
@@ -50,6 +50,8 @@ public class Constants {
     public static final String FRAGS = "Guardian fragments";
     public static final String ESS = "Guardian essence";
     public static final String PORTAL = "Portal";
+    public static final int PORTAL_SPAWN = 43729;
+
     public static final String CATALYTIC_ENERGY = "Catalytic guardian stone";
     public static final String ELEMENTAL_ENERGY = "Elemental guardian stone";
     public static final String GREAT_GUARDIAN = "The Great Guardian";


### PR DESCRIPTION
- Bug Fix: Player could get stuck at mining guardian parts indefinitely. Needed an extra conditional (line 629-631) to get out of it.
- Bug Fix: isPortalSpawned returned true at some times causing the player to get stuck in a loop at the Large Mine rubble stairs.
- QOL: lowers priority for depositing runes, which ensures portal has higher priority
- QOL: made overlay a bit bigger, state was sometimes overlapping left side text
- QOL: added config option for prioritizing going to portal ASAP. if toggled off, will remain same and first drop/deposit runes before running to the portal