### PR TITLE
GOTR: More xp/hour and extra feature

### DIFF
--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsConfig.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsConfig.java
@@ -1,9 +1,6 @@
 package com.piggyplugins.AutoRifts;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
-import net.runelite.client.config.Keybind;
+import net.runelite.client.config.*;
 
 
 @ConfigGroup("AutoRifts")
@@ -18,11 +15,67 @@ public interface AutoRiftsConfig extends Config {
         return Keybind.NOT_SET;
     }
 
+    @ConfigSection(
+            name = "Game Tick Configuration",
+            description = "Configure how the bot handles game tick delays, 1 game tick equates to roughly 600ms",
+            position = 1,
+            closedByDefault = true
+    )
+    String delayTickConfig = "delayTickConfig";
+
+    @Range(
+            max = 10
+    )
+    @ConfigItem(
+            keyName = "tickDelayMin",
+            name = "Game Tick Min",
+            description = "",
+            position = 2,
+            section = delayTickConfig
+    )
+    default int tickDelayMin() {
+        return 1;
+    }
+
+    @Range(
+            max = 10
+    )
+    @ConfigItem(
+            keyName = "tickDelayMax",
+            name = "Game Tick Max",
+            description = "",
+            position = 3,
+            section = delayTickConfig
+    )
+    default int tickDelayMax() {
+        return 3;
+    }
+
+    @ConfigItem(
+            keyName = "tickDelayEnabled",
+            name = "Tick delay",
+            description = "enables some tick delays",
+            position = 4,
+            section = delayTickConfig
+    )
+    default boolean tickDelay() {
+        return true;
+    }
+
+    @ConfigSection(
+            name = "Auto Rifts Configuration",
+            description = "Configure your settings for the AutoRifts plugin",
+            position = 2,
+            closedByDefault = true
+    )
+    String autoRiftsConfig = "autoRiftsConfig";
+
     @ConfigItem(
             keyName = "startFrags",
             name = "Starting Fragments",
             description = "How many fragments you should get before leaving the starting zone",
-            position = 1
+            position = 1,
+            section = autoRiftsConfig
     )
     default int startingFrags() {
         return 60;
@@ -32,7 +85,8 @@ public interface AutoRiftsConfig extends Config {
             keyName = "minFrags",
             name = "Minimum Fragments",
             description = "When you should mine more fragments",
-            position = 2
+            position = 2,
+            section = autoRiftsConfig
     )
     default int minFrags() {
         return 24;
@@ -42,7 +96,8 @@ public interface AutoRiftsConfig extends Config {
             keyName = "ignorePortal",
             name = "Ignore Portal Ess",
             description = "How much essence you should have to ignore portal",
-            position = 3
+            position = 3,
+            section = autoRiftsConfig
     )
     default int ignorePortal() {
         return 20;
@@ -52,17 +107,28 @@ public interface AutoRiftsConfig extends Config {
             keyName = "dropRunes",
             name = "Drop Runes",
             description = "Drop Runes instead of depositing (kek uim)",
-            position = 4
+            position = 4,
+            section = autoRiftsConfig
     )
     default boolean dropRunes() {
         return false;
     }
 
     @ConfigItem(
+            keyName = "dropRunesFilter",
+            name = "Drop Runes Filter",
+            description = "If Drop Runes is not enabled and this has runes entered, the type of rune entered here will still get dropped, others will get deposited (ex: air, Mind, Body). Add runes with full name, air rune, mind rune , cosmic rune, etc... and split with comma ','",
+            position = 5,
+            section = autoRiftsConfig
+    )
+    default String dropRunesFilter() {return "";}
+
+    @ConfigItem(
             keyName = "usePouches",
             name = "Use Essence Pouches?",
             description = "Requires NPC Contact runes in Rune Pouch or Redwood lit Lantern",
-            position = 6
+            position = 6,
+            section = autoRiftsConfig
     )
     default boolean usePouches() {
         return false;
@@ -72,7 +138,8 @@ public interface AutoRiftsConfig extends Config {
             keyName = "hasBook",
             name = "Abyssal Book in bank? (IMPORTANT FOR NPC CONTACT)",
             description = "IMPORTANT TO USE NPC CONTACT",
-            position = 7
+            position = 7,
+            section = autoRiftsConfig
     )
     default boolean hasBook() {
         return true;
@@ -82,7 +149,8 @@ public interface AutoRiftsConfig extends Config {
             keyName = "prioritizeCatalytic",
             name = "Prioritizes Catalytic Energy",
             description = "Will try to balance points if not ticked",
-            position = 8
+            position = 8,
+            section = autoRiftsConfig
     )
     default boolean prioritizeCatalytic() {
         return true;
@@ -92,7 +160,8 @@ public interface AutoRiftsConfig extends Config {
             keyName = "prioritizeHigher",
             name = "Prioritize Higher Tier Runes(BETA)",
             description = "Prioritizes Nature/Law/Death/Blood even if points arent balanced - Expect some bugs",
-            position = 9
+            position = 9,
+            section = autoRiftsConfig
     )
     default boolean prioritizeHighTier() {
         return true;
@@ -102,7 +171,8 @@ public interface AutoRiftsConfig extends Config {
             keyName = "prioritizePortal",
             name = "Prioritize Portal(BETA)",
             description = "Prioritizes Portal, mainly affects when to drop/deposit runes - Expect some bugs",
-            position = 10
+            position = 10,
+            section = autoRiftsConfig
     )
     default boolean prioritizePortal() {
         return true;

--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
@@ -807,9 +807,9 @@ public class AutoRiftsPlugin extends Plugin {
     }
 
     private boolean shouldDropSpecificRunes(){
-        String runeConfigFilterNoSpaces = config.dropRunesFilter().replaceAll("\\s", "");
-        String[] runeFilterConfig = runeConfigFilterNoSpaces.split(",");
+        String[] runeFilterConfig = config.dropRunesFilter().split(",");
         for (String rune : runeFilterConfig) {
+            rune = rune.trim();
             Optional<Widget> runeToDrop = Inventory.search().matchesWildCardNoCase(rune).first();
             if(runeToDrop.isPresent()){
                 return true;

--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
@@ -807,7 +807,8 @@ public class AutoRiftsPlugin extends Plugin {
     }
 
     private boolean shouldDropSpecificRunes(){
-        String[] runeFilterConfig = config.dropRunesFilter().split(",");
+        String runeConfigFilterNoSpaces = config.dropRunesFilter().replaceAll("\\s", "");
+        String[] runeFilterConfig = runeConfigFilterNoSpaces.split(",");
         for (String rune : runeFilterConfig) {
             Optional<Widget> runeToDrop = Inventory.search().matchesWildCardNoCase(rune).first();
             if(runeToDrop.isPresent()){

--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/AutoRiftsPlugin.java
@@ -274,7 +274,7 @@ public class AutoRiftsPlugin extends Plugin {
     }
 
     private int tickDelay() {
-        return ThreadLocalRandom.current().nextInt(0, 3);
+        return config.tickDelay() ? ThreadLocalRandom.current().nextInt(config.tickDelayMin(), config.tickDelayMax()) : 0;
     }
 
     private void handleState(State state) {
@@ -611,7 +611,7 @@ public class AutoRiftsPlugin extends Plugin {
         }
         TileObject barrier = tileObject.get();
         TileObjectInteraction.interact(barrier, "Quick-pass");
-        timeout = tickDelay();
+        timeout = 1;
     }
 
     private void waitForGame() {
@@ -666,7 +666,11 @@ public class AutoRiftsPlugin extends Plugin {
                     return State.ENTER_PORTAL;
                 }
             }
-            return State.ANIMATING;
+            if(client.getLocalPlayer().getAnimation() == 9361 || client.getLocalPlayer().getAnimation() == 791){
+                //lol do nothing, was too lazy to create something else, this works to circumvent the delay with crafting runes and giving to guardian
+            }else{
+                return State.ANIMATING;
+            }
         }
 
         if (pouchesDegraded()) {
@@ -704,10 +708,15 @@ public class AutoRiftsPlugin extends Plugin {
 
         if(!config.prioritizePortal()){ //old way - non prioritize portal
             if (shouldDepositRunes()) {
+
                 if (config.dropRunes()) {
                     return State.DROP_RUNES;
                 }
-                return State.DEPOSIT_RUNES;
+                if(shouldDropSpecificRunes()){
+                    return State.DROP_RUNES;
+                }else{
+                    return State.DEPOSIT_RUNES;
+                }
             }
         }
 
@@ -755,7 +764,11 @@ public class AutoRiftsPlugin extends Plugin {
                 if (config.dropRunes()) {
                     return State.DROP_RUNES;
                 }
-                return State.DEPOSIT_RUNES;
+                if(shouldDropSpecificRunes()){
+                    return State.DROP_RUNES;
+                }else{
+                    return State.DEPOSIT_RUNES;
+                }
             }
         }
 
@@ -791,6 +804,17 @@ public class AutoRiftsPlugin extends Plugin {
 
     private boolean hasUnchargedCells() {
         return InventoryUtil.hasItem(Constants.UNCHARGED_CELLS);
+    }
+
+    private boolean shouldDropSpecificRunes(){
+        String[] runeFilterConfig = config.dropRunesFilter().split(",");
+        for (String rune : runeFilterConfig) {
+            Optional<Widget> runeToDrop = Inventory.search().matchesWildCardNoCase(rune).first();
+            if(runeToDrop.isPresent()){
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean hasPowerEssence() {


### PR DESCRIPTION
QoL: You can now disable or decide tick delays in the config. It is under the "Game Tick Configuration" section. Before: random tick delay of between 0 and 3 was done after most interactions. Now you can decide yourself or even disable it (so then tick delay is 0). Try it out! This also directly changes how fast you can empty and craft runes (check out the difference! It's really cool!)

QoL: Added exception for animation delay while crafting runes and giving essence to the guardian. This speeds up the xp/hour and provides those precious few seconds that you sometimes need to get into the portal!

QoL: Added a config option to drop specific runes, even if you do not have drop runes enabled in the config. This means you can  decide to drop body and mind runes for example but still keep depositing blood runes and the others. Only the runes in the config, split by comma, will be dropped. This also speeds up going for portal because you don't have to deposit the "bad" runes.

Preliminary tests have shown a 5-8% increase in xp/hour with lower tick delays and the animation skip for crafting and giving essence to the guardian.

Example of new config: 
![image](https://github.com/0Hutch/PiggyPlugins/assets/25319266/ee756a23-f5a8-4c3e-91c7-c1bed6784da4)
