### PR TITLE
fix: bad check for food in inventory in rooftops

### DIFF
--- a/RooftopAgility/src/main/java/com/piggyplugins/RooftopAgility/RooftopAgilityPlugin.java
+++ b/RooftopAgility/src/main/java/com/piggyplugins/RooftopAgility/RooftopAgilityPlugin.java
@@ -266,7 +266,7 @@ public class RooftopAgilityPlugin extends Plugin {
         }
 
         if (!config.foodName().isBlank()) {
-            return Inventory.search().nameContains(config.foodName().toLowerCase()).empty();
+            return InventoryUtil.nameContainsNoCase(config.foodName()).empty();
         }
 
         if (config.boostWithPie()) {


### PR DESCRIPTION
Rooftops was checking for food with no case, which pretty much always returned false, so it would get stuck restocking