### PR TITLE
bugFix/LavaRunecrafter/breakHandler

### DIFF
--- a/LavaRunecrafter/src/main/java/com/example/LavaRunecrafter/LavaRunecrafterPlugin.java
+++ b/LavaRunecrafter/src/main/java/com/example/LavaRunecrafter/LavaRunecrafterPlugin.java
@@ -72,12 +72,14 @@ public class LavaRunecrafterPlugin extends Plugin {
         timeout = 0;
         pouches = new HashMap<>();
         breakHandler.registerPlugin(this);
+        breakHandler.startPlugin(this);
     }
 
     @Override
     public void shutDown() {
         timeout = 0;
         pouches = new HashMap<>();
+        breakHandler.stopPlugin(this);
         breakHandler.unregisterPlugin(this);
     }
 


### PR DESCRIPTION
Breakhandler was bugged when running Lava Runecrafter. It never starts its countdown which results in the player never taking a break. This pull request closes this issue.

Bug:
<img width="243" alt="Screenshot 2023-12-11 at 10 50 50 PM" src="https://github.com/0Hutch/PiggyPlugins/assets/46418742/d71bb180-0b3a-4319-9655-7f600c0d549f">

Bug Fix:
<img width="241" alt="Screenshot 2023-12-11 at 10 51 15 PM" src="https://github.com/0Hutch/PiggyPlugins/assets/46418742/dbb683ae-a3bf-4066-b870-78d74ca740ec">
