### PR TITLE
bump runeLiteVersion to 1.10.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
         jcenter()
     }
 
-    def runeLiteVersion = '1.10.19'
+    def runeLiteVersion = '1.10.22'
 
     plugins.withType(JavaPlugin) {
         dependencies {


### PR DESCRIPTION
fixes the compiler from not being able to find
 ```
@Override
public Widget createStaticChild(int type)
``` 
and fixes the compiler error for the missing `TitleCaseListCellRenderer` class