### PR TITLE
Fix `hasItems()` returning true for partial name matching (ItemCombiner)

### DIFF
--- a/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
+++ b/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
@@ -157,7 +157,7 @@ public class ItemCombinerPlugin extends Plugin {
     private boolean hasItems(boolean bank) {
         return bank
                 ? !BankInventory.search().withName(config.itemOneName()).empty() && !BankInventory.search().withName(config.itemTwoName()).empty()
-                : InventoryUtil.hasItem(config.itemOneName()) && InventoryUtil.hasItems(config.itemTwoName());
+                : Inventory.search().withName(config.itemOneName()).first().isPresent() && Inventory.search().withName(config.itemTwoName()).first().isPresent();
     }
 
     private void doBanking() {


### PR DESCRIPTION
Fixes an issue where `hasItems()` can return true if you have an item such as `Ruby bolt tips` and your secondary item is set to `Ruby`