### PR TITLE
Add banking support for `Bank Chest` and `Bank Chest-wreck` (ItemCombiner)

### DIFF
--- a/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
+++ b/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
@@ -63,7 +63,6 @@ public class ItemCombinerPlugin extends Plugin {
     @Getter
     private boolean started;
     private int afkTicks;
-    private boolean deposit;
     private boolean isMaking;
     private boolean debug = true;
 
@@ -144,14 +143,8 @@ public class ItemCombinerPlugin extends Plugin {
             NPCInteraction.interact(banker.get(), "Bank");
             return;
         }
-        if (!chest.isPresent() && !booth.isPresent() && !banker.isPresent()){
-            client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "couldn't find bank or banker", null);
-            EthanApiPlugin.stopPlugin(this);
-        }
-
-        if (!deposit) {
-            deposit = true;
-        }
+        client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "couldn't find bank or banker", null);
+        EthanApiPlugin.stopPlugin(this);
     }
 
     private boolean hasItems(boolean bank) {

--- a/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
+++ b/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
@@ -128,11 +128,16 @@ public class ItemCombinerPlugin extends Plugin {
     }
 
     private void findBank() {
-        Optional<TileObject> chest = TileObjects.search().withName("Bank chest").nearestToPlayer();
+        Optional<TileObject> chest1 = TileObjects.search().withName("Bank chest").nearestToPlayer();
+        Optional<TileObject> chest2 = TileObjects.search().withName("Bank Chest").nearestToPlayer();
         Optional<NPC> banker = NPCs.search().withAction("Bank").nearestToPlayer();
         Optional<TileObject> booth = TileObjects.search().withAction("Bank").nearestToPlayer();
-        if (chest.isPresent()){
-            TileObjectInteraction.interact(chest.get(), "Use");
+        if (chest1.isPresent()){
+            TileObjectInteraction.interact(chest1.get(), "Use");
+            return;
+        }
+        if (chest2.isPresent()){
+            TileObjectInteraction.interact(chest2.get(), "Use");
             return;
         }
         if (booth.isPresent()){

--- a/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
+++ b/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
@@ -130,6 +130,7 @@ public class ItemCombinerPlugin extends Plugin {
     private void findBank() {
         Optional<TileObject> chest1 = TileObjects.search().withName("Bank chest").nearestToPlayer();
         Optional<TileObject> chest2 = TileObjects.search().withName("Bank Chest").nearestToPlayer();
+        Optional<TileObject> chest3 = TileObjects.search().withName("Bank Chest-wreck").nearestToPlayer();
         Optional<NPC> banker = NPCs.search().withAction("Bank").nearestToPlayer();
         Optional<TileObject> booth = TileObjects.search().withAction("Bank").nearestToPlayer();
         if (chest1.isPresent()){
@@ -138,6 +139,10 @@ public class ItemCombinerPlugin extends Plugin {
         }
         if (chest2.isPresent()){
             TileObjectInteraction.interact(chest2.get(), "Use");
+            return;
+        }
+        if (chest3.isPresent()){
+            TileObjectInteraction.interact(chest3.get(), "Use");
             return;
         }
         if (booth.isPresent()){


### PR DESCRIPTION
Previously, chests with the name `Bank Chest` (not `Bank chest`) were ignored (for example, the chest outside of Guardians of the Rift); this fixes that.

Also, added support for `Bank Chest-wreck`, for the really cool players who do their bankstanding on the island off the coast of Fossil Island.