### PR TITLE
Add idle failsafe to prevent plugin stalling if interrupted (ItemCombiner)

### DIFF
--- a/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
+++ b/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
@@ -104,6 +104,13 @@ public class ItemCombinerPlugin extends Plugin {
             isMaking = false;
         }
 
+        if(client.getLocalPlayer().getAnimation() == -1 && isMaking){
+                afkTicks++;
+        }
+        if(afkTicks >= 25){
+                isMaking = false;
+        }
+
         if (isMaking) {
             return;
         }


### PR DESCRIPTION
This prevents a possible scenario where your client will cease to combine items if interrupted (for example, when you receive the level-up dialog) by setting `isMaking` to `false` if your players animation is the idle animation for more than `25` ticks.

It's not the best solution but it works. I set the tick count to arbitrary `25` in case there's some items that can be combined that don't change your animation or something.

If you'd like, I can add a configuration option to enable/disable this feature and set the tick amount to a different number.