### PR TITLE
Correct key presses and event firing order (SixHourLog)

### DIFF
--- a/SixHourLog/src/main/java/com/piggyplugins/SixHourLog/SixHourLogPlugin.java
+++ b/SixHourLog/src/main/java/com/piggyplugins/SixHourLog/SixHourLogPlugin.java
@@ -55,11 +55,8 @@ public class SixHourLogPlugin extends Plugin {
     }
 
     private void pressKey() {
-        KeyEvent keyPress = new KeyEvent(this.client.getCanvas(), KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0, KeyEvent.VK_SPACE, KeyEvent.CHAR_UNDEFINED);
-        this.client.getCanvas().dispatchEvent(keyPress);
-        KeyEvent keyRelease = new KeyEvent(this.client.getCanvas(), KeyEvent.KEY_RELEASED, System.currentTimeMillis(), 0, KeyEvent.VK_SPACE, KeyEvent.CHAR_UNDEFINED);
-        this.client.getCanvas().dispatchEvent(keyRelease);
-        KeyEvent keyTyped = new KeyEvent(this.client.getCanvas(), KeyEvent.KEY_TYPED, System.currentTimeMillis(), 0, KeyEvent.VK_SPACE, KeyEvent.CHAR_UNDEFINED);
-        this.client.getCanvas().dispatchEvent(keyTyped);
+        this.client.getCanvas().dispatchEvent(new KeyEvent(this.client.getCanvas(), KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0, KeyEvent.VK_SPACE, ' ', 1));
+        this.client.getCanvas().dispatchEvent(new KeyEvent(this.client.getCanvas(), KeyEvent.KEY_TYPED, System.currentTimeMillis(), 0, KeyEvent.VK_UNDEFINED, ' ', 0));
+        this.client.getCanvas().dispatchEvent(new KeyEvent(this.client.getCanvas(), KeyEvent.KEY_RELEASED, System.currentTimeMillis(), 0, KeyEvent.VK_SPACE, ' ', 1));
     }
 }


### PR DESCRIPTION
This commit fixes the key presses that are submitted by `SixHourLogPlugin`. After some investigation into how key presses worked, and how to emulate them correctly, I decided to create this class to assist:

```java
 public class KeyPressedListener implements KeyListener
{
	@Override
	public void keyTyped(KeyEvent e) {
		logkey("keyTyped", e);
	}

	@Override
	public void keyPressed(KeyEvent e) {
		logkey("keyPressed", e);
	}

	@Override
	public void keyReleased(KeyEvent e) {
		logkey("keyReleased", e);
	}

	private void logkey(String event, KeyEvent e){
		log.debug(event
				+ "; ID: " + e.getID()
				+ "; When: " + e.getWhen()
				+ "; Mods: " + e.getModifiersEx()
				+ "; Code: " + e.getKeyCode()
				+ "; Char: (" + e.getKeyChar() + ")"
				+ "; Loc: " + e.getKeyLocation());
	}
}
```

This allowed me to receive output for when `KeyPressed`, `KeyTyped`, and `KeyReleased` are fired. Notice that `KeyPressed` and `KeyTyped` are always fired with the same `getWhen()` value, and `KeyReleased` has a slight delay.

```KeyPressedListener - keyPressed; ID: 401; When: 1713817445195; Mods: 0; Code: 72; Char: (h); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817445195; Mods: 0; Code: 0; Char: (h); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817445307; Mods: 0; Code: 72; Char: (h); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817445396; Mods: 0; Code: 75; Char: (k); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817445396; Mods: 0; Code: 0; Char: (k); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817445512; Mods: 0; Code: 75; Char: (k); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817445586; Mods: 0; Code: 76; Char: (l); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817445586; Mods: 0; Code: 0; Char: (l); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817445679; Mods: 0; Code: 76; Char: (l); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817445768; Mods: 0; Code: 59; Char: (;); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817445768; Mods: 0; Code: 0; Char: (;); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817445879; Mods: 0; Code: 59; Char: (;); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817445883; Mods: 0; Code: 72; Char: (h); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817445883; Mods: 0; Code: 0; Char: (h); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817445998; Mods: 0; Code: 72; Char: (h); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817446029; Mods: 0; Code: 75; Char: (k); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817446029; Mods: 0; Code: 0; Char: (k); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817446154; Mods: 0; Code: 75; Char: (k); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817446264; Mods: 0; Code: 74; Char: (j); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817446265; Mods: 0; Code: 0; Char: (j); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817446348; Mods: 0; Code: 74; Char: (j); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817446397; Mods: 0; Code: 71; Char: (g); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817446397; Mods: 0; Code: 0; Char: (g); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817446512; Mods: 0; Code: 71; Char: (g); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817446516; Mods: 0; Code: 85; Char: (u); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817446516; Mods: 0; Code: 0; Char: (u); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817446652; Mods: 0; Code: 85; Char: (u); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817446707; Mods: 0; Code: 89; Char: (y); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817446707; Mods: 0; Code: 0; Char: (y); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817446777; Mods: 0; Code: 89; Char: (y); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817446802; Mods: 0; Code: 79; Char: (o); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817446803; Mods: 0; Code: 0; Char: (o); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817446885; Mods: 0; Code: 79; Char: (o); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817447005; Mods: 0; Code: 80; Char: (p); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817447006; Mods: 0; Code: 0; Char: (p); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817447091; Mods: 0; Code: 80; Char: (p); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817447312; Mods: 0; Code: 32; Char: ( ); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817447312; Mods: 0; Code: 0; Char: ( ); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817447408; Mods: 0; Code: 32; Char: ( ); Loc: 1
KeyPressedListener - keyPressed; ID: 401; When: 1713817447480; Mods: 0; Code: 32; Char: ( ); Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713817447480; Mods: 0; Code: 0; Char: ( ); Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713817447568; Mods: 0; Code: 32; Char: ( ); Loc: 1
```

The last 6 lines are the output received when you press the space bar (twice). Currently, the plugin triggers output like this:

```
KeyPressedListener - keyPressed; ID: 401; When: 1713817516173; Mods: 0; Code: 32; Char: ?; Loc: 0
KeyPressedListener - keyPressed; ID: 401; When: 1713817516767; Mods: 0; Code: 32; Char: ?; Loc: 0
KeyPressedListener - keyPressed; ID: 401; When: 1713817517368; Mods: 0; Code: 32; Char: ?; Loc: 0
```

It seems that the `KeyTyped` and `KeyReleased` events are not even being fired for some reason.

With the changes in this commit, I was able to receive the same output that is triggered by an organic keypress:

```
KeyPressedListener - keyPressed; ID: 401; When: 1713818665854; Mods: 0; Code: 32; Char:  ; Loc: 1
KeyPressedListener - keyTyped; ID: 400; When: 1713818665858; Mods: 0; Code: 0; Char:  ; Loc: 0
KeyPressedListener - keyReleased; ID: 402; When: 1713818665864; Mods: 0; Code: 32; Char:  ; Loc: 1```