### PR TITLE
Fix `hasItems()` partial name matching (ItemCombiner)

### DIFF
--- a/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
+++ b/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerPlugin.java
@@ -157,7 +157,7 @@ public class ItemCombinerPlugin extends Plugin {
     private boolean hasItems(boolean bank) {
         return bank
                 ? !BankInventory.search().withName(config.itemOneName()).empty() && !BankInventory.search().withName(config.itemTwoName()).empty()
-                : InventoryUtil.hasItem(config.itemOneName()) && InventoryUtil.hasItems(config.itemTwoName());
+                : Inventory.search().withName(config.itemOneName()).first().isPresent() && Inventory.search().withName(config.itemTwoName()).first().isPresent();
     }
 
     private void doBanking() {


### PR DESCRIPTION
Fixes an issue where `hasItems()` can return true for partial name matches; for example, if you have an item such as `Ruby bolts` and your secondary item is set to `Ruby`, we will get unexpected behavior

Swapped `InventoryUtil.hasItems(name)` with `Inventory.search().withName(name)`; `hasItems()` uses `InventoryUtil.nameContainsNoCase()` with the passed string, which can result in unexpected behavior.