### PR TITLE
Swap `runeLiteVersion` to `latest.release`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
         jcenter()
     }
 
-    def runeLiteVersion = '1.10.31.1'
+    def runeLiteVersion = 'latest.release'
 
     plugins.withType(JavaPlugin) {
         dependencies {


### PR DESCRIPTION
This will automatically use the latest client version to avoid updating repositories unnecessarily in the future.