### PR TITLE
Added support for amulet of chemistry (ItemCombiner) and fix for colossal pouch bug (AutoRift)

### DIFF
--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/PouchManager.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/PouchManager.java
@@ -139,7 +139,7 @@ public class PouchManager {
                 Widget p = emptyPouch.get();
                 InventoryInteraction.useItem(p, "Fill");
                 int essenceWithdrawn = pouch.getEssenceTotal() - pouch.getCurrentEssence();
-                if (essenceAmount - essenceWithdrawn > 0) {
+                if (essenceAmount >= essenceWithdrawn) {
                     essenceAmount -= essenceWithdrawn;
                     pouch.setCurrentEssence(pouch.getEssenceTotal());
                 } else {

--- a/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerConfig.java
+++ b/ItemCombiner/src/main/java/com/piggyplugins/ItemCombiner/ItemCombinerConfig.java
@@ -12,7 +12,7 @@ public interface ItemCombinerConfig extends Config {
             keyName = "Toggle",
             name = "Toggle",
             description = "",
-            position = 0
+            position = 1
     )
     default Keybind toggle() {
         return Keybind.NOT_SET;
@@ -21,7 +21,7 @@ public interface ItemCombinerConfig extends Config {
     @ConfigSection(
             name = "Configuration",
             description = "Config for item combiner",
-            position = 1
+            position = 0
     )
     String configuration = "Configuration";
 
@@ -29,7 +29,8 @@ public interface ItemCombinerConfig extends Config {
             keyName = "itemOneName",
             name = "Item One (Tool/Vial)",
             description = "Name of the first item",
-            position = 2
+            position = 2,
+            section = configuration
     )
     default String itemOneName() {
         return "";
@@ -39,7 +40,8 @@ public interface ItemCombinerConfig extends Config {
             keyName = "itemOneAmt",
             name = "Item One Amount",
             description = "Amount of the first item",
-            position = 3
+            position = 3,
+            section = configuration
     )
     default int itemOneAmt() {
         return 14;
@@ -49,7 +51,8 @@ public interface ItemCombinerConfig extends Config {
             keyName = "itemTwoName",
             name = "Item Two (Herb/Second/Gem/Etc.)",
             description = "Name of the second item",
-            position = 4
+            position = 4,
+            section = configuration
     )
     default String itemTwoName() {
         return "";
@@ -59,9 +62,20 @@ public interface ItemCombinerConfig extends Config {
             keyName = "itemTwoAmt",
             name = "Item Two Amount",
             description = "Amount of the second item",
-            position = 4
+            position = 4,
+            section = configuration
     )
     default int itemTwoAmt() {
         return 14;
+    }
+
+    @ConfigItem(
+            keyName = "amuletOfChemistry",
+            name = "Use amulet of chemistry",
+            description = "Tick if you want to use amulet of chemistry",
+            position = 5,
+            section = configuration
+    )
+    default boolean amuletOfChemistry() {return false;
     }
 }


### PR DESCRIPTION
**ItemCombiner:** 
- Fail-safe/correction for mid-inventory interruptions (e.g. level-up message)

- Can now start the plugin with non-empty inventory

- Ensured that the potion widget will be clicked even if there is an uneven number of items in the inventory (typically occurs on last inventory when an uneven number of material are banked)

- Removed the condition `client.getLocalPlayer().getAnimation() != -1` from the initial check to make banking a bit faster