### PR TITLE
Looting no longer finds location (AutoCombat)

### DIFF
--- a/AutoCombat/src/main/java/com/polyplugins/AutoCombat/AutoCombatPlugin.java
+++ b/AutoCombat/src/main/java/com/polyplugins/AutoCombat/AutoCombatPlugin.java
@@ -18,7 +18,7 @@ import com.polyplugins.AutoCombat.util.Util;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import static net.runelite.api.TileItem.OWNERSHIP_SELF;
-import static net.runelite.api.TileItem.OWNERSHIP_OTHER;
+import static net.runelite.api.TileItem.OWNERSHIP_GROUP;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.*;
@@ -331,7 +331,7 @@ public class AutoCombatPlugin extends Plugin {
 		final LocalPoint location = tile.getLocalLocation();
         // Should keep it in sync with lootQueue
         if (item.getOwnership() == OWNERSHIP_SELF || 
-                item.getOwnership() == OWNERSHIP_OTHER) {
+                item.getOwnership() == OWNERSHIP_GROUP) {
             lootLocation.add(location);
         }
 	}


### PR DESCRIPTION
LocalPoint location deprecated in ItemStack
See runelite commit [#b0907b9](https://github.com/runelite/runelite/commit/b0907b96bf7e47375611fbd8b0aff4f3577c6730)
Using ItemSpawned event to keep track of location