### PR TITLE
Jagex Launcher Linux script

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -2,9 +2,15 @@
 Knowledge of Lutris, gaming on Linux, etc. A guide for that is not the scope of this.
 
 ## Instructions
-Local import the <code>jagex-launcher.yml</code> into Lutris, it should do everything for you.<br><br>
-**Gotchas:**<br>
-Make sure to have the correct jdk installed. The current runner fully qualifies Eclipse Temurin's jdk on Fedora.
+Local import the <code>jagex-launcher.yml</code> into Lutris, it should do everything for you.
+#### Gotchas:
+Make sure to have the correct jdk and path. The current <code>runelite.sh</code> fully qualifies Eclipse Temurin's jdk on Fedora.<br><br>
+You can find and edit the current <code>runelite.sh</code> in the Wine prefix Lutris installed.<br><br>
+(Example path):
+```
+/Games/jagex-launcher/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh
+```
+Or locally rework the provided <code>runelite.sh</code> and source it in the Lutris install.
 ### Install jdk
 #### Fedora:
 (Taken from https://adoptium.net/installation/linux/)<br>
@@ -24,7 +30,7 @@ EOF
 ```
 # yum install temurin-11-jdk
 ```
-And the current runner's java bin path will work!<br>
+And the current <code>runelite.sh</code> java bin path will work!<br>
 #### Gentoo:
 ```
 # emerge --ask dev-java/openjdk-bin:11
@@ -33,9 +39,9 @@ And the current runner's java bin path will work!<br>
 $ eselect java-vm list
 ```
 ```
-# eselect java-vm set system openjdk-bin-11-my_number
+# eselect java-vm set system my_number
 ```
-Java path for runner:
+Java path for <code>runelite.sh</code>:
 ```
 /usr/lib/nvm/openjdk-bin-11/bin/java
 ```

--- a/linux/README.md
+++ b/linux/README.md
@@ -2,7 +2,10 @@
 Knowledge of Lutris, gaming on Linux, etc. A guide for that is not the scope of this.
 
 ## Instructions
-Local import the <code>jagex-launcher.yml</code> into Lutris, it should do everything for you.
+<code>git clone</code> the repo.<br><br>
+Import the <code>jagex-launcher.yml</code> into Lutris.<br><br>
+For <code>runelite.sh</code>, source what was provided in the repo and change as needed.<br><br>
+Lutris should take care of everything for you!
 #### Gotchas:
 Make sure to have the correct jdk and path. The current <code>runelite.sh</code> fully qualifies Eclipse Temurin's jdk on Fedora.<br><br>
 You can find and edit the current <code>runelite.sh</code> in the Wine prefix Lutris installed.<br><br>

--- a/linux/README.md
+++ b/linux/README.md
@@ -8,12 +8,12 @@ For <code>runelite.sh</code>, source what was provided in the repo and change as
 Lutris should take care of everything for you!
 #### Gotchas:
 Make sure to have the correct jdk and path. The current <code>runelite.sh</code> fully qualifies Eclipse Temurin's jdk on Fedora.<br><br>
-You can find and edit the current <code>runelite.sh</code> in the Wine prefix Lutris installed.<br><br>
+After the fact, you can find and edit the current <code>runelite.sh</code> in the Wine prefix Lutris installed.<br><br>
 (Example path):
 ```
 /Games/jagex-launcher/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh
 ```
-Or locally rework the provided <code>runelite.sh</code> and source it in the Lutris install.
+(Or rework the provided <code>runelite.sh</code> before sourcing it in the Lutris install)
 ### Install jdk
 #### Fedora:
 (Taken from https://adoptium.net/installation/linux/)<br>

--- a/linux/README.md
+++ b/linux/README.md
@@ -52,8 +52,8 @@ Java path for <code>runelite.sh</code>:
 
 ## Help
 Unless you have a wonky setup, the path for the classes should work.<br><br>
-If it doesn't, run <code>lutris -d</code> with debug enabled. If the class path can't be loaded, it's a FULLY qualified path. Make sure the path matches the lutris install directory for the wine prefix.<br><br>
-From experience, if the problem isn't with lutris, it's from paths. Fully qualified paths will reduce errors and likely be the fix. If the class path isn't loading, find your paths and use fully qualified paths.
+If it doesn't, run <code>lutris -d</code> with debug enabled. If the class path can't be loaded, it's a FULLY qualified path. Make sure the path matches the Lutris install directory for the Wine prefix.<br><br>
+From experience, if the problem isn't with Lutris, it's from paths. Fully qualified paths will reduce errors and likely be the fix. If the class path isn't loading, find your paths and use fully qualified paths.
 
 ## Credit
 Lutris yaml has been heavily borrowed from [TormStorm's jagex-launcher-linux](https://github.com/TormStorm/jagex-launcher-linux).<br><br>

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,14 +1,15 @@
-# Assumptions
-Know how to use Lutris.
+## Assumptions
+Knowledge of Lutris, gaming on Linux, etc. A guide for that is not the scope of this.
 
-# Instructions
-Import the local yaml into Lutris, it should do everything for you.
-**BUT:**
-* Make sure to have the correct jdk installed. The current runner fully qualifies eclipse temurin's jdk on Fedora.
-## Install jdk
-### Fedora:
-(Taken from https://adoptium.net/installation/linux/)
-<code># Uncomment and change the distribution name if you are not using CentOS/RHEL/Fedora
+## Instructions
+Local import the <code>jagex-launcher.yml</code> into Lutris, it should do everything for you.<br><br>
+**Gotchas:**<br>
+Make sure to have the correct jdk installed. The current runner fully qualifies Eclipse Temurin's jdk on Fedora.
+### Install jdk
+#### Fedora:
+(Taken from https://adoptium.net/installation/linux/)<br>
+```
+# Uncomment and change the distribution name if you are not using CentOS/RHEL/Fedora
 # DISTRIBUTION_NAME=centos
 
 cat <<EOF > /etc/yum.repos.d/adoptium.repo
@@ -18,20 +19,33 @@ baseurl=https://packages.adoptium.net/artifactory/rpm/${DISTRIBUTION_NAME:-$(. /
 enabled=1
 gpgcheck=1
 gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public
-EOF</code>
-<code># yum install temurin-11-jdk</code></br>
-And the current runner's java bin path will work!</br>
-### Gentoo:
-<code># emerge --ask dev-java/openjdk-bin:11</code>
-<code>$ eselect java-vm list</code>
-<code># eselect java-vm set system openjdk-bin-11-my_number</code>
-Java path for runner: <code>/usr/lib/nvm/openjdk-bin-11/bin/java</code>
-(note: Gentoo main repo bin is compiled by eclipse temurin)<br>
+EOF
+```
+```
+# yum install temurin-11-jdk
+```
+And the current runner's java bin path will work!<br>
+#### Gentoo:
+```
+# emerge --ask dev-java/openjdk-bin:11
+```
+```
+$ eselect java-vm list
+```
+```
+# eselect java-vm set system openjdk-bin-11-my_number
+```
+Java path for runner:
+```
+/usr/lib/nvm/openjdk-bin-11/bin/java
+```
+(Note: Gentoo's main repo bin is compiled by Eclipse Temurin)
 
-# Help
-Unless you have a wonky setup, the path for the classes should work.
-If it doesn't, run <code>lutris -d</code> with debug enabled. If the class path can't be loaded, it's a FULLY qualified path. Make sure the path matches the lutris install directory for the wine prefix.
+## Help
+Unless you have a wonky setup, the path for the classes should work.<br><br>
+If it doesn't, run <code>lutris -d</code> with debug enabled. If the class path can't be loaded, it's a FULLY qualified path. Make sure the path matches the lutris install directory for the wine prefix.<br><br>
 From experience, if the problem isn't with lutris, it's from paths. Fully qualified paths will reduce errors and likely be the fix. If the class path isn't loading, find your paths and use fully qualified paths.
 
-# Credit
-Lutris yaml has been heavily borrowed from [TormStorm's jagex-launcher-linux](https://github.com/TormStorm/jagex-launcher-linux). I've repurposed it to work with EthanApi and PiggyPlugins.
+## Credit
+Lutris yaml has been heavily borrowed from [TormStorm's jagex-launcher-linux](https://github.com/TormStorm/jagex-launcher-linux).<br><br>
+I've repurposed it to work with EthanApi and PiggyPlugins.

--- a/linux/README.md
+++ b/linux/README.md
@@ -46,7 +46,7 @@ $ eselect java-vm list
 ```
 Java path for <code>runelite.sh</code>:
 ```
-/usr/lib/nvm/openjdk-bin-11/bin/java
+/usr/lib/jvm/openjdk-bin-11/bin/java
 ```
 (Note: Gentoo's main repo bin is compiled by Eclipse Temurin)
 

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,0 +1,37 @@
+# Assumptions
+Know how to use Lutris.
+
+# Instructions
+Import the local yaml into Lutris, it should do everything for you.
+**BUT:**
+* Make sure to have the correct jdk installed. The current runner fully qualifies eclipse temurin's jdk on Fedora.
+## Install jdk
+### Fedora:
+(Taken from https://adoptium.net/installation/linux/)
+<code># Uncomment and change the distribution name if you are not using CentOS/RHEL/Fedora
+# DISTRIBUTION_NAME=centos
+
+cat <<EOF > /etc/yum.repos.d/adoptium.repo
+[Adoptium]
+name=Adoptium
+baseurl=https://packages.adoptium.net/artifactory/rpm/${DISTRIBUTION_NAME:-$(. /etc/os-release; echo $ID)}/\$releasever/\$basearch
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public
+EOF</code>
+<code># yum install temurin-11-jdk</code></br>
+And the current runner's java bin path will work!</br>
+### Gentoo:
+<code># emerge --ask dev-java/openjdk-bin:11</code>
+<code>$ eselect java-vm list</code>
+<code># eselect java-vm set system openjdk-bin-11-my_number</code>
+Java path for runner: <code>/usr/lib/nvm/openjdk-bin-11/bin/java</code>
+(note: Gentoo main repo bin is compiled by eclipse temurin)<br>
+
+# Help
+Unless you have a wonky setup, the path for the classes should work.
+If it doesn't, run <code>lutris -d</code> with debug enabled. If the class path can't be loaded, it's a FULLY qualified path. Make sure the path matches the lutris install directory for the wine prefix.
+From experience, if the problem isn't with lutris, it's from paths. Fully qualified paths will reduce errors and likely be the fix. If the class path isn't loading, find your paths and use fully qualified paths.
+
+# Credit
+Lutris yaml has been heavily borrowed from [TormStorm's jagex-launcher-linux](https://github.com/TormStorm/jagex-launcher-linux). I've repurposed it to work with EthanApi and PiggyPlugins.

--- a/linux/jagex-launcher.yml
+++ b/linux/jagex-launcher.yml
@@ -1,0 +1,80 @@
+name: Jagex Launcher
+game_slug: jagex-launcher
+version: Installer
+slug: jagex-launcher-installer
+runner: wine
+
+script:
+  files:
+    - installer: https://github.com/TormStorm/jagex-launcher-linux/releases/download/v1.0.1/installer.py
+    - requirements: https://github.com/TormStorm/jagex-launcher-linux/releases/download/v1.0.1/requirements.txt
+    - runelite: https://github.com/runelite/launcher/releases/download/2.7.1/RuneLite.jar
+    - runelite-launcher: https://github.com/agge3/PiggyPlugins/blob/linux/runelite.sh
+    - runelite-hijack: https://github.com/Ethan-Vann/Installer/releases/download/1.0/RuneliteHijack.jar
+    - piggy-plugins:  https://github.com/0Hutch/PiggyPlugins/releases/download/release/piggy-plugins-aio-1.2.7.jar 
+  require-binaries: python3
+  game:
+    exe: $GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/JagexLauncher.exe
+    prefix: $GAMEDIR
+  wine:
+    overrides:
+      jscript.dll: native
+  installer:
+    - input_menu:
+        description: 'This is an unofficial installer, use is at your own risk. Please read the following licence agreement carefully: https://www.jagex.com/en-GB/terms/eula'
+        id: EULA
+        options:
+        - accept: "Accept"
+        - decline: "Decline"
+        preselect: decline
+    - task:
+        name: create_prefix
+        prefix: "$GAMEDIR"
+    - task:
+        name: set_regedit
+        type: REG_SZ
+        path: HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\RuneLite Launcher_is1
+        key: InstallLocation
+        prefix: $GAMEDIR
+        value: C:\\Program Files (x86)\\Jagex Launcher\\Games\\RuneLite
+    - execute:
+        command: |
+            # Adding this duplicate check for the EULA, because otherwise the user could go back, and then forward in the installer and lutris skips that check for some reason.
+            if [ "$INPUT_EULA" = "accept" ]; then
+                echo "End user licence agreement accepted, continuing installation..."
+            else
+                echo "End user licence agreement must be accepted before continuing, quitting installation..."
+                exit 1
+            fi
+            mkdir -p "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher"
+            cd "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher"
+            python3 -m venv env
+            source env/bin/activate
+            python3 -m pip install -r "$requirements"
+            python3 "$installer"
+        description: Installing the jagex-launcher files
+    - task:
+        name: winekill
+        prefix: $GAMEDIR
+    - execute:
+        command: mkdir -p "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/"
+        description: Creating game directory
+    - merge:
+        src: runelite-hijack
+        dst: "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite"
+    - chmodx: "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/EthanVannInstaller.jar"
+    - merge:
+        src: runelite
+        dst: "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite"
+    - chmodx: runelite
+    - merge:
+        src: runelite-launcher
+        dst: "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite"
+    - chmodx: "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh"
+    - execute:
+        command: ln -s "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/runelite.sh" "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/RuneLite.exe"
+    - execute:
+        command: mkdir -p $HOME/.runelite/externalplugins
+    - merge:
+        src: piggy-plugins
+        dst: $HOME/.runelite/externalplugins

--- a/linux/jagex-launcher.yml
+++ b/linux/jagex-launcher.yml
@@ -9,7 +9,7 @@ script:
     - installer: https://github.com/TormStorm/jagex-launcher-linux/releases/download/v1.0.1/installer.py
     - requirements: https://github.com/TormStorm/jagex-launcher-linux/releases/download/v1.0.1/requirements.txt
     - runelite: https://github.com/runelite/launcher/releases/download/2.7.1/RuneLite.jar
-    - runelite-launcher: https://github.com/agge3/PiggyPlugins/blob/linux/runelite.sh
+    - runelite-launcher: $HOME/PiggyPlugins/runelite.sh
     - runelite-hijack: https://github.com/Ethan-Vann/Installer/releases/download/1.0/RuneliteHijack.jar
     - piggy-plugins:  https://github.com/0Hutch/PiggyPlugins/releases/download/release/piggy-plugins-aio-1.2.7.jar 
   require-binaries: python3
@@ -62,7 +62,6 @@ script:
     - merge:
         src: runelite-hijack
         dst: "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite"
-    - chmodx: "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite/EthanVannInstaller.jar"
     - merge:
         src: runelite
         dst: "$GAMEDIR/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite"

--- a/linux/runelite.sh
+++ b/linux/runelite.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# gamedir from lutris
+GAMEDIR="Games"
+
+# fully qualified java path
+java="/usr/lib/jvm/temurin-11-jdk/bin/java"
+
+# fully qualified lutris install path
+path="${HOME}/${GAMEDIR}/jagex-launcher/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite"
+
+# runelite hijack
+class="${path}/EthanVannInstaller.jar:${path}/RuneLite.jar"
+main="ca.arnah.runelite.LauncherHijack"
+
+# for debug
+echo ${path}
+echo ${class}
+echo ${main}
+
+"${java}" -cp "${class}" $@ "${main}"

--- a/linux/runelite.sh
+++ b/linux/runelite.sh
@@ -10,7 +10,7 @@ java="/usr/lib/jvm/temurin-11-jdk/bin/java"
 path="${HOME}/${GAMEDIR}/jagex-launcher/drive_c/Program Files (x86)/Jagex Launcher/Games/RuneLite"
 
 # runelite hijack
-class="${path}/EthanVannInstaller.jar:${path}/RuneLite.jar"
+class="${path}/RuneliteHijack.jar:${path}/RuneLite.jar"
 main="ca.arnah.runelite.LauncherHijack"
 
 # for debug


### PR DESCRIPTION
Instructions are self-explanatory
Caveats are having the correct java bin path
Different Wine prefix paths (up to the user), they should review runelite.sh
Sourcing the runelite.sh script in the install
Have Lutris and other dependencies installed
Tested and confirmed on Fedora and Gentoo Linux
Issues with maintainability would be changing the http queries with updates
(Suggested): Include runelite.sh in releases and have the yaml grab that
(vs. now just git cloning the repo and sourcing local)