### PR TITLE
Fixed the notorious colossal pouch bug

### DIFF
--- a/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/PouchManager.java
+++ b/AutoRifts/src/main/java/com/piggyplugins/AutoRifts/PouchManager.java
@@ -129,21 +129,25 @@ public class PouchManager {
         }
         return false;
     }
-
+    
     public void fillPouches() {
         int essenceAmount = Inventory.getItemAmount(ItemID.GUARDIAN_ESSENCE);
         List<Pouch> result = getEmptyPouches();
+
         for (Pouch pouch : result) {
             Optional<Widget> emptyPouch = Inventory.search().withId(pouch.getPouchID()).first();
             if (emptyPouch.isPresent()) {
                 Widget p = emptyPouch.get();
                 InventoryInteraction.useItem(p, "Fill");
                 int essenceWithdrawn = pouch.getEssenceTotal() - pouch.getCurrentEssence();
-                if (essenceAmount - essenceWithdrawn > 0) {
+                if (essenceAmount - essenceWithdrawn >= 0) {
                     essenceAmount -= essenceWithdrawn;
                     pouch.setCurrentEssence(pouch.getEssenceTotal());
                 } else {
-                    pouch.setCurrentEssence(essenceAmount);
+                    pouch.setCurrentEssence(pouch.getCurrentEssence() + essenceAmount);
+                    essenceAmount = 0;
+                }
+                if (essenceAmount == 0) {
                     break;
                 }
             }


### PR DESCRIPTION
This commit ensures that the colossal pouch is correctly filled even if the exact amount of essence needed matches the available essence. The original condition (> 0) would incorrectly skip setting the pouch to full if the essence amounts were exactly equal, leading to inconsistent pouch states. Unsure why it didn't occur for other pouch types but I've tested this for 6+ hours now with no issues on both a colossal pouch account and a non-colossal pouch account.